### PR TITLE
[Response] Add response type for {:created, id, version}

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -4,6 +4,7 @@ defmodule X3m.System.Response do
           | {:ok, any}
           | {:ok, any, integer}
           | {:created, any}
+          | {:created, any, integer}
           | {:service_unavailable, atom}
           | {:service_timeout, atom, String.t(), non_neg_integer}
           | {:validation_error, map}


### PR DESCRIPTION
When MessageHandler executes **execute_on_aggregate** successfully, the response written to SysMsg is `{:created, id, version}` and so the `X3m.System.Response` module needs a return type to reflect that possibility