### PR TITLE
[Router] Refactor to eliminate dialyzer error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.8.5
+
+- Fix typo in raised ArgumentError if passed `:ensure_local_logging?` value is
+  not `boolean()`
+- Refactor internal function to eliminate dialyzer error from client apps
+
 # 0.8.4
 
 - Bump elixir to 1.11

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -120,7 +120,7 @@ defmodule X3m.System.Router do
       @spec unquote(service_name)(Message.t()) :: :ok
       def unquote(service_name)(%Message{service_name: unquote(service_name)} = message) do
         message.logger_metadata
-        |> _set_logger_local_group_leader(@ensure_local_logging)
+        |> _set_logger_local_group_leader()
         |> Logger.metadata()
 
         X3m.System.Instrumenter.execute(:service_request_received, %{}, %{
@@ -221,7 +221,7 @@ defmodule X3m.System.Router do
         raise(
           ArgumentError,
           """
-          `:ensure_local_logging?` is expect to be boolean!
+          `:ensure_local_logging?` is expected to be boolean!
           Check that you are passing either atom `true` or `false`.
           """
         )
@@ -302,7 +302,7 @@ defmodule X3m.System.Router do
 
       def _invoke(:local, message_handler, f, message) do
         message.logger_metadata
-        |> _set_logger_local_group_leader(@ensure_local_logging)
+        |> _set_logger_local_group_leader()
         |> Logger.metadata()
 
         mono_start = System.monotonic_time()
@@ -375,14 +375,12 @@ defmodule X3m.System.Router do
       def choose_node(_sys_msg),
         do: :local
 
-      @spec _set_logger_local_group_leader(keyword(), boolean()) :: keyword()
-      defp _set_logger_local_group_leader(logger_metadata, ensure_local_logging?)
-
-      defp _set_logger_local_group_leader(logger_metadata, false),
-        do: logger_metadata
-
-      defp _set_logger_local_group_leader(logger_metadata, true),
-        do: Keyword.put(logger_metadata, :gl, Process.whereis(:user))
+      @spec _set_logger_local_group_leader(keyword()) :: keyword()
+      defp _set_logger_local_group_leader(logger_metadata) do
+        if @ensure_local_logging,
+          do: Keyword.put(logger_metadata, :gl, Process.whereis(:user)),
+          else: logger_metadata
+      end
 
       defoverridable choose_node: 1
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule X3m.System.MixProject do
   def project do
     [
       app: :x3m_system,
-      version: "0.8.4",
+      version: "0.8.5",
       elixir: "~> 1.11",
       source_url: "https://github.com/x3m-ex/system",
       description: """


### PR DESCRIPTION
- fixes typo in raised ArgumentException if passed value to `:ensure_local_logging?` is not `boolean()`
- refactors internal function to use if so that dialyzer error is not emitted in client apps